### PR TITLE
Fix docs for viewing code package logs

### DIFF
--- a/docs/conceptual-docs/application-deployment-quickstart.md
+++ b/docs/conceptual-docs/application-deployment-quickstart.md
@@ -111,7 +111,7 @@ For each codepackage (container) in your service instance, you can check its sta
 1. Check the logs for each container instance in a CGS. In this example, we are going to fetch the logs from the container VotingWeb.Code, which is in the first replica of the service VotingWeb
 	
 ```cli
-az sbz codepackage logs --resource-group <myResourceGroup> --application-name SbzVoting --service-name VotingWeb --replica-name 0 --code-package-name VotingWeb.Code
+az sbz codepackage logs --resource-group <myResourceGroup> --application-name SbzVoting --service-name VotingWeb --replica-name 0 --name VotingWeb.Code
 ```
 
 


### PR DESCRIPTION
When ran log command from the docs I got:

```
az sbz codepackage logs --resource-group seabreeze --application-name SbzVoting --service-name VotingWeb --replica-name 0 --code-package-name VotingWeb.code
az sbz codepackage logs: error: the following arguments are required: --name/-n
usage: az sbz codepackage logs [-h] [--verbose] [--debug]
                               [--output {json,jsonc,table,tsv}]
                               [--query JMESPATH] --resource-group
                               RESOURCE_GROUP_NAME --app-name APPLICATION_NAME
                               --service-name SERVICE_NAME --replica-name
                               REPLICA_NAME --name CODE_PACKAGE_NAME
                               [--tail TAIL]
```

Running help on the command it looks like `--name-code-package` got changed to `--name`