### PR TITLE
Flush data after writing to file

### DIFF
--- a/samples/src/azurefiles-volume/Program.cs
+++ b/samples/src/azurefiles-volume/Program.cs
@@ -8,6 +8,7 @@ namespace AzureFilesVolumeTestApp
     using System;
     using System.IO;
     using System.Threading;
+    using System.Text;
     using System.Reflection;
 
     class Program
@@ -26,7 +27,14 @@ namespace AzureFilesVolumeTestApp
             for(;;)
             {
                 sequenceNumber++;
-                File.WriteAllText(dataFileFullPath, sequenceNumber.ToString());
+
+                using (var file = new FileStream(dataFileFullPath, FileMode.OpenOrCreate, FileAccess.Write))
+                {
+                    var bytes = Encoding.ASCII.GetBytes(sequenceNumber.ToString());
+                    file.Write(bytes, 0, bytes.Length);
+                    file.Flush();
+                }
+
                 Thread.Sleep(PauseBetweenUpdatesMillisec);
             }
         }


### PR DESCRIPTION
Flush data after writing to file.
This ensures that End2End tests work in SFRP.
Test:
1) This app is used for generating baseline sfvolumedisk app.
2) Upgrade app checks for the presence of file with a number.

If flush does not happen, then file content can be empty. Test fails.